### PR TITLE
Increase test delays to encourage greenness

### DIFF
--- a/src/test/java/io/github/barnardb/infrajav/grpc/test/ActiveNameResolverTest.java
+++ b/src/test/java/io/github/barnardb/infrajav/grpc/test/ActiveNameResolverTest.java
@@ -82,7 +82,7 @@ class ActiveNameResolverTest {
         InetAddress initialAddress = InetAddress.getByAddress(new byte[]{1, 1, 1, 1});
         underlyingFactory.setAddresses("foo", initialAddress);
 
-        NameResolver.Factory factory = new ActiveNameResolverFactory(underlyingFactory, 300, TimeUnit.MILLISECONDS);
+        NameResolver.Factory factory = new ActiveNameResolverFactory(underlyingFactory, 500, TimeUnit.MILLISECONDS);
 
         try (TestLogHandler log = TestLogHandler.forClass(ActiveNameResolver.class)) {
             NameResolver nameResolver = factory.newNameResolver(new URI("dns:///foo:1234"), null);
@@ -107,7 +107,7 @@ class ActiveNameResolverTest {
 
                 assertThat(log.records, hasSize(0));
 
-                waitAtMost(350, TimeUnit.MILLISECONDS)
+                waitAtMost(550, TimeUnit.MILLISECONDS)
                         .pollDelay(10, TimeUnit.MILLISECONDS)
                         .ignoreExceptionsInstanceOf(IndexOutOfBoundsException.class)
                         .until(() -> log.records.remove(0).getMessage(), is("Triggering scheduled refresh"));


### PR DESCRIPTION
The tests are failing on Travis CI, seemingly because
things are slow there. If this approach doesn't work,
we may need to change the way the test is written.